### PR TITLE
Fix Windows build target command line options

### DIFF
--- a/build/projects/XercescProject.py
+++ b/build/projects/XercescProject.py
@@ -138,12 +138,12 @@ class XercescProject (Project):
 
         if platform == 'win32':
             import shutil
+            
+            # Avoid name collision with variable
             import platform as platform_lib
             
             if platform_lib.architecture()[0] == "64bit":
                 platform = "x64"
-            else:
-                platform = "Win32"
           
             sln = 'projects/Win32/%s/xerces-all/xerces-all.sln' % ctx.build_type.upper ()
             configs = ['Debug|%s' % platform,

--- a/build/projects/XercescProject.py
+++ b/build/projects/XercescProject.py
@@ -138,8 +138,13 @@ class XercescProject (Project):
 
         if platform == 'win32':
             import shutil
-
-            platform = os.getenv('Platform')
+            import platform as platform_lib
+            
+            if platform_lib.architecture()[0] == "64bit":
+                platform = "x64"
+            else:
+                platform = "Win32"
+          
             sln = 'projects/Win32/%s/xerces-all/xerces-all.sln' % ctx.build_type.upper ()
             configs = ['Debug|%s' % platform,
                        'Release|%s' % platform,


### PR DESCRIPTION
This resolves issue #5 

os.getenv('Platform') returns 'None', the default value.
Checking platform.architecture() instead lets us know if the machine is 64-bit or not, and then we can change the variable if needed.
