### PR TITLE
Assorted Issues with bczar

### DIFF
--- a/build/projects/DocMiddlewareProject.py
+++ b/build/projects/DocMiddlewareProject.py
@@ -145,6 +145,9 @@ class DocMiddlewareProject(Project):
     ACE_ROOT = os.environ['ACE_ROOT']
     config_prefix = ''
     force_no_hidden_visibility = False
+	
+    # Patch to turn off _copy_value() as pure virtual function so that models will build.
+    config_prefix = config_prefix + "\r\n#define TAO_VALUETYPE_COPY_VALUE_IS_NOT_PURE"
 
     # We need to define the platform_macros.GNU script if we are not
     # running on a Windows environment.
@@ -188,7 +191,7 @@ class DocMiddlewareProject(Project):
         config_file = 'config-linux.h'
         # If we are building on an ARM, make an extra definition in config.h
         if platform.machine().startswith('arm'):
-          config_prefix = '#define ACE_GCC_HAS_TEMPLATE_INSTANTIATION_VISIBILITY_ATTRS 1'
+          config_prefix = config_prefix + '\r\n#define ACE_GCC_HAS_TEMPLATE_INSTANTIATION_VISIBILITY_ATTRS 1'
           force_no_hidden_visibility = True
 
       # Create a symbolic link to the target platform macros.

--- a/build/projects/XercescProject.py
+++ b/build/projects/XercescProject.py
@@ -38,7 +38,7 @@ class XercescProject (Project):
     def __init__ (self):
         Project.__init__ (self, 'XercesC')
 
-        self.__location__ = 'xerces-c-3.1.3'
+        self.__location__ = 'xerces-c-3.1.4'
         self.__dll_version__ = '3_1'
         self._basename_ = self.__location__
         

--- a/build/projects/XercescProject.py
+++ b/build/projects/XercescProject.py
@@ -38,7 +38,7 @@ class XercescProject (Project):
     def __init__ (self):
         Project.__init__ (self, 'XercesC')
 
-        self.__location__ = 'xerces-c-3.1.2'
+        self.__location__ = 'xerces-c-3.1.3'
         self.__dll_version__ = '3_1'
         self._basename_ = self.__location__
         


### PR DESCRIPTION
## DOC Middleware:

In older version of DOC CUTS used, **ACE+TAO+CIAO+DaNCE 6.1.8** there was a virtual function defined within [$TAO_ROOT/tao/Valuetype/ValueBase.h](https://github.com/DOCGroup/ACE_TAO/blob/829b320b1cc9d61f5c5ccbd3358d486d30f25557/TAO/tao/Valuetype/ValueBase.h#L144) called '''CORBA::ValueBase *
CORBA::ValueBase::_copy_value (void)'''. It also had an in header implementation.

When CUTS moved to [ACE+TAO+CIAO+DaNCE >= 6.2.0](https://github.com/DOCGroup/ACE_TAO/blob/master/TAO/NEWS#L162) a define marco was added to define the function **CORBA::ValueBase::_copy_value(void)** as either pure virtual or virtual. By default, this function is now treated as a pure virtual function, thus any sub-class of this class requires an implementation to be defined in the sub-class to compiled. Due to this change, all DDS based HelloWorld Models would fail compilation. g++ stated that sub class was missing the implemenation of the function **_copy_value(void)** in **RTIDDS_HelloWorld_ComponentsC.h**

To fix this, the config-linux.h file generated by **/build/projects/DocMiddlewareProject.py** has had the macro defined such that the function is treated as virtual, instead of pure virtual. This allows CUTS models/examples to be compiled for DDS.
## Xerces Version change:

The version of XercesC that the script attempts to download no longer exists at the URL listed. [3.1.2 can be still found](https://archive.apache.org/dist/xerces/c/3/sources/). The script **/build/projects/XercescProject.py** has been modified to point towards version 3.1.3 instead of 3.1.2 and appears to work for CUTS models.
